### PR TITLE
Rewrite recursion schemes part via deriving base functor and other instances

### DIFF
--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -43,29 +43,29 @@ normalize = identity
 
 convertToApply :: KtExpr -> KtExpr
 convertToApply = cata alg where
-  alg (Call a [b]) =  ktCall (ktProperty a (varRefUnqual $ MkKtIdent "app")) [b]
-  alg a = Fix a
+  alg (CallF a [b]) =  Call (Property a (varRefUnqual $ MkKtIdent "app")) [b]
+  alg a = embed a
 
 -- If a when case does not cover all cases, an else branch is needed
 -- since Kotlin can sometimes not infer, that all cases are covered, this adds a default case
 addElseCases :: KtExpr -> KtExpr
 addElseCases = cata alg where
   alg :: KtExprF KtExpr -> KtExpr
-  alg (WhenExpr cases) = ktWhenExpr $ reverse $ case reverse cases of
+  alg (WhenExprF cases) = WhenExpr $ reverse $ case reverse cases of
       [] -> []
       (WhenCase [] b : cs) -> ElseCase b : cs
       cs -> ElseCase errorMsg : cs
       where 
-        errorMsg = ktAsAny (ktCall (varRefUnqual $ MkKtIdent "error") [ktString "Error in Pattern Match"])
-  alg a = Fix a
+        errorMsg = ktAsAny (Call (varRefUnqual $ MkKtIdent "error") [ktString "Error in Pattern Match"])
+  alg a = embed a
 
 -- <mod>.<f>.app(<mod>.<cls>).app(<a>).app(<b>)
 pattern CallOn2 mod cls mod' f a b = 
-  (CallApp
-    (Fix (CallApp
-      (Fix (CallApp
-        (Fix (VarRef (Qualified (Just mod') f)))
-        (Fix (VarRef (Qualified (Just mod) cls)))
+  (CallAppF
+    ((CallApp
+      ((CallApp
+        ((VarRef (Qualified (Just mod') f)))
+        ((VarRef (Qualified (Just mod) cls)))
       ))
       a
     ))
@@ -76,14 +76,14 @@ inline :: KtExpr -> KtExpr
 inline = cata alg where
   alg :: KtExprF KtExpr -> KtExpr
   alg (CallOn2 Semigroup (MkKtIdent "semigroupString") Semigroup (MkKtIdent "append") a b)
-    = ktAdd (ktAsString a) (ktAsString b)
+    = Binary Add (ktAsString a) (ktAsString b)
   alg (CallOn2 Semigroup (MkKtIdent "semigroupArray") Semigroup (MkKtIdent "append") a b)
-    = ktAdd (ktAsList a) (ktAsList b)
-  alg a = Fix a
+    = Binary Add (ktAsList a) (ktAsList b)
+  alg a = embed a
 
 -- `Prim.undefined` is used for arguments that are not used by the reciever (from what I can tell)
 -- we'll give `Prim.undefined` the value Unit
 primUndefToUnit :: KtExpr -> KtExpr
-primUndefToUnit = cata (Fix . alg) where
-  alg (VarRef (Qualified (Just PrimModule) (MkKtIdent ident))) | ident == C.undefined = VarRef $ Qualified Nothing (MkKtIdent "Unit")
-  alg a = a
+primUndefToUnit = cata alg where
+  alg (VarRefF (Qualified (Just PrimModule) (MkKtIdent ident))) | ident == C.undefined = VarRef $ Qualified Nothing (MkKtIdent "Unit")
+  alg a = embed a


### PR DESCRIPTION
Hello @csicar. 

I think when we use normal ADT and derive base functor is more clear.
Also looks like u don't have `CodeGen.MagicDo` in your repo.

Thx