### PR TITLE
Magic do inlining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 	stack install
 	
 .PHONY: all
-all:  build test-codegen test-generatekt install test run
+all:  build test-codegen test-generatekt install 
 
 .PHONY: run
 run: test
@@ -15,12 +15,13 @@ run: test
 
 .PHONY: test
 test:
-	kotlinc kotlin/*.kt kotlin/Foreign/*.kt -include-runtime -d kotlin/bin.jar
+	kotlinc kotlin/*.kt kotlin/foreigns/*.kt -include-runtime -d kotlin/bin.jar
 	
 
 test-generatekt: build
 	stack exec -- pskt\
-		test/output/*/corefn.json\
+		test/output/Main/corefn.json\
+		-f "../foreigns/*.kt"\
 		-o ./kotlin/\
 
 		# -i "test/output/*/corefn.json"\

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -146,7 +146,9 @@ addRuntime folder = do
       "",
       "fun Any.app(arg: Any): Any {",
           "return (this as (Any) -> Any)(arg)",
-      "}"
+      "}",
+      "",
+      "fun Any.appRun() = (this as () -> Any)()"
     ]
 
 processFile :: CliOptions -> FilePath -> FilePath -> IO ()

--- a/pskt.cabal
+++ b/pskt.cabal
@@ -29,6 +29,7 @@ source-repository head
 library
   exposed-modules:
       CodeGen.Constants
+      CodeGen.MagicDo
       CodeGen.CoreImp
       CodeGen.Transformations
       CodeGen.KtCore

--- a/src/CodeGen/Constants.hs
+++ b/src/CodeGen/Constants.hs
@@ -29,6 +29,8 @@ pattern Applicative = ModuleName [ProperName "PS", ProperName "Control", ProperN
 pattern Effect = ModuleName [ProperName "PS", ProperName "Effect", ProperName "Module"]
 pattern Bind = ModuleName [ProperName "PS", ProperName "Control", ProperName "Bind", ProperName "Module"]
 
+pattern STInternal = ModuleName [ProperName "PS", ProperName "Control", ProperName "Monad", ProperName "ST", ProperName "Internal", ProperName "Module" ]
+
 isReserved :: Text -> Bool
 isReserved = (`elem` allReserved)
 

--- a/src/CodeGen/CoreImp.hs
+++ b/src/CodeGen/CoreImp.hs
@@ -192,7 +192,7 @@ moduleToKt mod = sequence
             (Left guardedExpr) -> traverse genGuard guardedExpr
                where 
                   genGuard (cond, val) = do
-                     ktCond <- ktAsBool . replaceBindersWithReferences (concat replacements) <$> exprToKt cond
+                     ktCond <- KtAsBool . replaceBindersWithReferences (concat replacements) <$> exprToKt cond
                      ktVal <- exprToKt val
                      pure $ WhenCase (concat guards ++ [ktCond]) (Stmt $ assignments ++ [ktVal])
 

--- a/src/CodeGen/CoreImp.hs
+++ b/src/CodeGen/CoreImp.hs
@@ -56,6 +56,7 @@ moduleToKt :: MonadSupply m => Module Ann -> m [KtExpr]
 moduleToKt mod = sequence
    [ pure $ packageDecl (moduleName mod)
    , pure $ Import [ProperName "Foreign", ProperName "PsRuntime"] (MkKtIdent "app")
+   , pure $ Import [ProperName "Foreign", ProperName "PsRuntime"] (MkKtIdent "appRun")
    , normalize <$> moduleToObject mod
    ]
    where

--- a/src/CodeGen/KtCore.hs
+++ b/src/CodeGen/KtCore.hs
@@ -47,6 +47,10 @@ data BinOp
   | Add
   deriving (Show)
 
+data UnaryOp
+  = Not 
+  deriving (Show)
+
 newtype KtIdent = MkKtIdent Text deriving (Show, Eq)
 runKtIdent (MkKtIdent a) = a
 
@@ -86,9 +90,11 @@ data KtExpr
   | ClassDecl [KtModifier] KtIdent [KtIdent] [KtExpr] KtExpr
   -- ^ class modifier; name; arguments; extends; body
   | If KtExpr KtExpr (Maybe KtExpr)
+  | While KtExpr KtExpr
   | WhenExpr [WhenCase KtExpr]
   | VariableIntroduction KtIdent KtExpr
   | Binary BinOp KtExpr KtExpr
+  | Unary UnaryOp KtExpr
   | Property KtExpr KtExpr
   | ArrayAccess KtExpr KtExpr
   | ObjectAccess KtExpr KtExpr
@@ -189,5 +195,8 @@ ktFun a b = Fun a [b]
 pattern CallAppF a b = (CallF (Property a (VarRef (Qualified Nothing (MkKtIdent "app")))) [b])
 pattern CallApp a b = (Call (Property a (VarRef (Qualified Nothing (MkKtIdent "app")))) [b])
 
+-- <a>.appRun()
 pattern RunF a = (CallF (Property a (VarRef (Qualified Nothing (MkKtIdent "appRun")))) [])
 pattern Run a = (Call (Property a (VarRef (Qualified Nothing (MkKtIdent "appRun")))) [])
+
+pattern Unit = VarRef (Qualified Nothing (MkKtIdent "Unit"))

--- a/src/CodeGen/KtCore.hs
+++ b/src/CodeGen/KtCore.hs
@@ -32,7 +32,7 @@ import Control.Arrow ((>>>))
 data WhenCase a
   -- Conditions, return value
   = WhenCase [a] a
-  | ElseCase a deriving (Show, Functor, Foldable, Traversable)
+  | ElseCase a deriving (Show, Functor, Foldable, Traversable, Eq)
 
 $(deriveShow1 ''WhenCase)
 $(deriveShow1 ''Literal)
@@ -45,11 +45,11 @@ data BinOp
   | And
   | To -- for Pairs: `1 to "Hi"`
   | Add
-  deriving (Show)
+  deriving (Show, Eq)
 
 data UnaryOp
   = Not 
-  deriving (Show)
+  deriving (Show, Eq)
 
 newtype KtIdent = MkKtIdent Text deriving (Show, Eq)
 runKtIdent (MkKtIdent a) = a
@@ -79,7 +79,7 @@ instance Foldable Literal where
 data KtModifier
   = Sealed
   | Data
-  deriving (Show)
+  deriving (Show, Eq)
 
 data KtExpr
   = Package [ProperName Namespace]
@@ -107,7 +107,7 @@ data KtExpr
   | Call KtExpr [KtExpr]
   | Const (Literal KtExpr)
   | Annotated KtExpr KtExpr
-  deriving (Show)
+  deriving (Show, Eq)
 
 makeBaseFunctor ''KtExpr
 deriveShow ''KtExprF

--- a/src/CodeGen/KtCore.hs
+++ b/src/CodeGen/KtCore.hs
@@ -97,6 +97,7 @@ data KtExpr
   | Fun (Maybe KtIdent) [KtIdent] KtExpr
   | FunRef (Qualified KtIdent)
   | Lambda KtIdent KtExpr
+  | Defer KtExpr -- Lambda without arguments; in Kotlin: { <body> }
   | Call KtExpr [KtExpr]
   | Const (Literal KtExpr)
   | Annotated KtExpr KtExpr
@@ -187,3 +188,6 @@ ktFun a b = Fun a [b]
 -- <a>.app(<b>)
 pattern CallAppF a b = (CallF (Property a (VarRef (Qualified Nothing (MkKtIdent "app")))) [b])
 pattern CallApp a b = (Call (Property a (VarRef (Qualified Nothing (MkKtIdent "app")))) [b])
+
+pattern RunF a = (CallF (Property a (VarRef (Qualified Nothing (MkKtIdent "appRun")))) [])
+pattern Run a = (Call (Property a (VarRef (Qualified Nothing (MkKtIdent "appRun")))) [])

--- a/src/CodeGen/KtCore.hs
+++ b/src/CodeGen/KtCore.hs
@@ -47,10 +47,6 @@ data BinOp
   | Add
   deriving (Show, Eq)
 
-data UnaryOp
-  = Not 
-  deriving (Show, Eq)
-
 newtype KtIdent = MkKtIdent Text deriving (Show, Eq)
 runKtIdent (MkKtIdent a) = a
 
@@ -94,7 +90,6 @@ data KtExpr
   | WhenExpr [WhenCase KtExpr]
   | VariableIntroduction KtIdent KtExpr
   | Binary BinOp KtExpr KtExpr
-  | Unary UnaryOp KtExpr
   | Property KtExpr KtExpr
   | ArrayAccess KtExpr KtExpr
   | ObjectAccess KtExpr KtExpr
@@ -177,8 +172,7 @@ ktString = Const . StringLiteral
 ktJvmValue :: KtExpr -> KtExpr
 ktJvmValue = Annotated (varRefUnqual $ MkKtIdent "JvmField")
 
-ktAsBool :: KtExpr -> KtExpr
-ktAsBool a = Cast a (varRefUnqual $ MkKtIdent "Boolean")
+pattern KtAsBool a = Cast a (VarRef (Qualified Nothing (MkKtIdent "Boolean")))
 
 ktAsAny :: KtExpr -> KtExpr
 ktAsAny a = Cast a (varRefUnqual $ MkKtIdent "Any")
@@ -200,3 +194,5 @@ pattern RunF a = (CallF (Property a (VarRef (Qualified Nothing (MkKtIdent "appRu
 pattern Run a = (Call (Property a (VarRef (Qualified Nothing (MkKtIdent "appRun")))) [])
 
 pattern Unit = VarRef (Qualified Nothing (MkKtIdent "Unit"))
+
+pattern Not a = Property (KtAsBool a) (Call (VarRef (Qualified Nothing (MkKtIdent "not"))) [])

--- a/src/CodeGen/MagicDo.hs
+++ b/src/CodeGen/MagicDo.hs
@@ -1,0 +1,59 @@
+module CodeGen.MagicDo where
+import Prelude (undefined)
+import Protolude hiding (Const, moduleName, undefined)
+import Protolude (unsnoc)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Maybe (catMaybes, fromMaybe, Maybe(..))
+import Data.List (nub)
+import Debug.Trace (trace)
+import Debug.Pretty.Simple (pTrace, pTraceShow, pTraceShowId)
+import Language.PureScript.CoreFn.Expr
+import Control.Monad.Supply.Class (MonadSupply, fresh)
+import Control.Monad (forM, replicateM, void)
+import Language.PureScript.CoreFn.Module
+import Language.PureScript.CoreFn.Meta
+import Language.PureScript.CoreFn.Ann
+import Control.Monad.Supply
+import Language.PureScript.AST.Literals
+import Data.Function (on)
+import Data.List (partition)
+import Language.PureScript.Names
+import Language.PureScript.CoreFn.Traversals
+import Language.PureScript.CoreFn.Binders
+import Language.PureScript.PSString (prettyPrintStringJS, PSString)
+import Data.Text.Prettyprint.Doc
+import Text.Pretty.Simple (pShow)
+import Debug.Pretty.Simple (pTraceShowId, pTraceShow)
+import Language.PureScript.AST.SourcePos (displayStartEndPos)
+import CodeGen.Constants
+import CodeGen.KtCore
+import Data.Functor.Foldable
+import Data.Maybe  (fromJust)
+import qualified Language.PureScript.Constants as C
+
+-- val main = PS.Control.Bind.Module.discard
+--                .app(PS.Control.Bind.Module.discardUnit)
+--                .app(PS.Effect.Module.bindEffect)
+--                .app(PS.Effect.Console.Module.log.app("asd"))
+--                .app({ _ : Any ->
+--        PS.Control.Bind.Module.discard.app(PS.Control.Bind.Module.discardUnit)
+--          .app(PS.Effect.Module.bindEffect)
+--          .app(PS.Effect.Console.Module.log.app("kkk"))
+--          .app({ _ : Any ->
+--            1
+--         })
+--     });
+-- log.app("asd")
+-- log.app("kkk")
+
+pattern QualRef a b = VarRef (Qualified (Just a) (MkKtIdent b))
+
+magicDoEffect :: KtExpr -> KtExpr
+magicDoEffect = cata alg where
+  alg :: KtExprF KtExpr -> KtExpr
+  -- PS.Control.Applicative.Module.pure
+  --              .app(PS.Effect.Module.applicativeEffect)
+  --              .app(a); ==> a
+  alg (CallAppF (CallApp (QualRef Applicative "pure") (QualRef Effect "applicativeEffect")) a) = a
+  alg other = pTraceShowId $ embed other

--- a/src/CodeGen/MagicDo.hs
+++ b/src/CodeGen/MagicDo.hs
@@ -93,6 +93,7 @@ magicDoEffect = cata alg where
   alg (RunF (CallApp (QualRef Effect "untilE") cond)) =
     Stmt [While (Unary Not (Run cond)) (Stmt []), Unit]
 
+  -- Desugar whileE
   alg (RunF (CallApp (CallApp (QualRef Effect "whileE") cond) body)) =
     Stmt [While (Run cond) (Stmt [Run body]), Unit]
   

--- a/src/CodeGen/Printer.hs
+++ b/src/CodeGen/Printer.hs
@@ -118,9 +118,11 @@ printExprAlg (FunRefF qualIdent) = parens $ "::" <> printQualified printKtIdent 
 printExprAlg (ConstF lit) = printLiteral lit
 printExprAlg (WhenExprF cases) = "when" <+> braceNested (vsep $ printWhenCases . fmap snd <$> cases)
 printExprAlg (BinaryF op (_, a) (_, b)) = parens $ a <+> printOp op <+> b
+printExprAlg (UnaryF op (_, a)) = parens $ printUnary op <+> a
 printExprAlg (ObjectAccessF (_, obj) (_, key)) = obj <> brackets key <> "!!"
 printExprAlg (CastF (_, a) (_, b)) = parens $ a <+> "as" <+> b
 printExprAlg (AnnotatedF (_, ann) (_, expr)) = "@" <> ann <> line <> expr
+printExprAlg (WhileF (_, cond) (_, body)) = "while" <+> parens cond <+> body
 printExprAlg a = pretty $ show a
 
 printOp Equals = "=="
@@ -128,6 +130,8 @@ printOp IsType = "is"
 printOp And = "&&"
 printOp To = "to"
 printOp Add = "+"
+
+printUnary Not = "!"
 
 printWhenCases (WhenCase conds body) = group (joinWith "&&" (ensureOneElement conds) <+> "->") <+> body
    where 

--- a/src/CodeGen/Printer.hs
+++ b/src/CodeGen/Printer.hs
@@ -29,7 +29,7 @@ import CodeGen.CoreImp
 moduleToText :: Module Ann -> SimpleDocStream ()
 moduleToText mod = layoutPretty defaultLayoutOptions $ vsep $ addAnnotations $ printExpr <$> moduleToKt' mod
    where
-      addAnnotations a = "@file:Suppress(\"UNCHECKED_CAST\")" : a
+      addAnnotations a = "@file:Suppress(\"UNCHECKED_CAST\")" <> line : a
 
 nest' = nest 2
 
@@ -97,7 +97,7 @@ printExprAlg :: KtExprF (KtExpr, Doc ()) -> Doc ()
 printExprAlg (PackageF ns) = "package" <+> joinWith' "." (pretty . runProperName <$> ns)
 printExprAlg (ImportF ns val) = "import" <+> joinWith' "." (pretty . runProperName <$> ns) <> "." <> printKtIdent val
 printExprAlg (StmtF []) = "{}"
-printExprAlg (StmtF stmts) = braceNested $ vsep $ (<> flatAlt "" ";")  . group . snd <$> stmts
+printExprAlg (StmtF stmts) = braceNested $ vsep $ (<> flatAlt ";" ";")  . group . snd <$> stmts
 printExprAlg (ObjectDeclF ident extends (_, body)) = "object" <+> maybe "" printKtIdent ident <+> extendsDoc (snd <$> extends) <+> body
 printExprAlg (ClassDeclF mods name args extends (_, body)) =
       hsep (printKtModifier <$> mods) <+> "class" <+> printKtIdent name 
@@ -106,9 +106,11 @@ printExprAlg (VarRefF qualIdent) = printQualified printKtIdent qualIdent
 printExprAlg (CallF (_, a) args) = group $ nest' (a <> "(" <> commaSep ((softline' <>) . snd <$> args)) <> softline' <> ")"
 printExprAlg (VariableIntroductionF ident (_, a)) = "val" <+> printKtIdent ident <+> "=" <+> a
 printExprAlg (LambdaF arg (Stmt stmts, body)) = braces $ nest' $ 
-   " " <> printKtIdent arg <+> ": Any ->" <> line' <> nest' (vsep $ (<> flatAlt "" ";") . group . printExpr <$> stmts)
+   " " <> printKtIdent arg <+> ": Any ->" <> line' <> nest' (vsep $ (<> flatAlt ";" ";") . group . printExpr <$> stmts)
 printExprAlg (LambdaF arg (_, body)) = braces $ (<> line') $ nest' $
    " " <> printKtIdent arg <+> ": Any ->" <> line' <+> body
+printExprAlg (DeferF (Stmt _, body)) = "/* defer stmt*/" <> body
+printExprAlg (DeferF (_, body)) = ("/* defer */" <>) $ braces $ nest' body
 printExprAlg (FunF mName args (_, body)) = 
    "fun" <+> maybe "" printKtIdent mName <> parens (commaSep $ (<+> ": Any") . printKtIdent <$> args) <> ": Any =" <+> body
 printExprAlg (PropertyF (_, a) (_, b)) = align $ nest' $ a <> line' <> "."  <> b

--- a/src/CodeGen/Printer.hs
+++ b/src/CodeGen/Printer.hs
@@ -109,7 +109,7 @@ printExprAlg (LambdaF arg (Stmt stmts, body)) = braces $ nest' $
    " " <> printKtIdent arg <+> ": Any ->" <> line' <> nest' (vsep $ (<> flatAlt ";" ";") . group . printExpr <$> stmts)
 printExprAlg (LambdaF arg (_, body)) = braces $ (<> line') $ nest' $
    " " <> printKtIdent arg <+> ": Any ->" <> line' <+> body
-printExprAlg (DeferF (Stmt _, body)) = "/* defer stmt*/" <> body
+printExprAlg (DeferF (Stmt _, body)) = "/* defer **/" <> body
 printExprAlg (DeferF (_, body)) = ("/* defer */" <>) $ braces $ nest' body
 printExprAlg (FunF mName args (_, body)) = 
    "fun" <+> maybe "" printKtIdent mName <> parens (commaSep $ (<+> ": Any") . printKtIdent <$> args) <> ": Any =" <+> body

--- a/src/CodeGen/Printer.hs
+++ b/src/CodeGen/Printer.hs
@@ -118,7 +118,6 @@ printExprAlg (FunRefF qualIdent) = parens $ "::" <> printQualified printKtIdent 
 printExprAlg (ConstF lit) = printLiteral lit
 printExprAlg (WhenExprF cases) = "when" <+> braceNested (vsep $ printWhenCases . fmap snd <$> cases)
 printExprAlg (BinaryF op (_, a) (_, b)) = parens $ a <+> printOp op <+> b
-printExprAlg (UnaryF op (_, a)) = parens $ printUnary op <+> a
 printExprAlg (ObjectAccessF (_, obj) (_, key)) = obj <> brackets key <> "!!"
 printExprAlg (CastF (_, a) (_, b)) = parens $ a <+> "as" <+> b
 printExprAlg (AnnotatedF (_, ann) (_, expr)) = "@" <> ann <> line <> expr
@@ -131,7 +130,6 @@ printOp And = "&&"
 printOp To = "to"
 printOp Add = "+"
 
-printUnary Not = "!"
 
 printWhenCases (WhenCase conds body) = group (joinWith "&&" (ensureOneElement conds) <+> "->") <+> body
    where 

--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -28,6 +28,7 @@ import Debug.Pretty.Simple (pTraceShowId, pTraceShow)
 import Language.PureScript.AST.SourcePos (displayStartEndPos)
 import CodeGen.Constants
 import CodeGen.KtCore
+import CodeGen.MagicDo
 import Data.Functor.Foldable
 import Data.Maybe  (fromJust)
 import qualified Language.PureScript.Constants as C
@@ -36,6 +37,7 @@ normalize :: KtExpr -> KtExpr
 normalize = identity
   . addElseCases
   . primUndefToUnit
+  . magicDoEffect
   -- . convertToApply
   . inline
 

--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -149,5 +149,5 @@ inline = cata alg where
 -- we'll give `Prim.undefined` the value Unit
 primUndefToUnit :: KtExpr -> KtExpr
 primUndefToUnit = cata alg where
-  alg (VarRefF (Qualified (Just PrimModule) (MkKtIdent ident))) | ident == C.undefined = VarRef $ Qualified Nothing (MkKtIdent "Unit")
+  alg (VarRefF (Qualified (Just PrimModule) (MkKtIdent ident))) | ident == C.undefined = Unit
   alg a = embed a

--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -36,9 +36,6 @@ import qualified Language.PureScript.Constants as C
 normalize :: KtExpr -> KtExpr
 normalize = identity
   . removeDoubleStmt
-  . primUndefToUnit
-  . addElseCases
-  . removeDoubleStmt
   . inlineDeferApp
   -- poor man's fixpoint
   . magicDoEffect
@@ -79,6 +76,7 @@ normalize = identity
   . removeDoubleStmt
   . removeUnnecessaryWhen
   . addElseCases
+  . primUndefToUnit
   . inline
 
 removeDoubleStmt :: KtExpr -> KtExpr

--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -39,6 +39,7 @@ normalize = identity
   . inlineDeferApp
   -- poor man's fixpoint
   . untilFixpoint magicDoEffect
+  . untilFixpoint magicDoST
   . removeDoubleStmt
   . removeUnnecessaryWhen
   . addElseCases

--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -38,46 +38,16 @@ normalize = identity
   . removeDoubleStmt
   . inlineDeferApp
   -- poor man's fixpoint
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
-  . magicDoEffect
+  . untilFixpoint magicDoEffect
   . removeDoubleStmt
   . removeUnnecessaryWhen
   . addElseCases
   . primUndefToUnit
   . inline
+
+untilFixpoint :: Eq a => (a -> a) -> a -> a
+untilFixpoint f a | f a == a = a
+untilFixpoint f a = untilFixpoint f (f a)
 
 removeDoubleStmt :: KtExpr -> KtExpr
 removeDoubleStmt = cata alg where

--- a/src/CodeGen/Transformations.hs
+++ b/src/CodeGen/Transformations.hs
@@ -37,10 +37,48 @@ normalize :: KtExpr -> KtExpr
 normalize = identity
   . removeDoubleStmt
   . primUndefToUnit
-  . removeUnnecessaryWhen
   . addElseCases
   . removeDoubleStmt
+  . inlineDeferApp
+  -- poor man's fixpoint
   . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . magicDoEffect
+  . removeDoubleStmt
+  . removeUnnecessaryWhen
+  . addElseCases
   . inline
 
 removeDoubleStmt :: KtExpr -> KtExpr
@@ -57,6 +95,22 @@ removeUnnecessaryWhen = cata alg where
   alg :: KtExprF KtExpr -> KtExpr
   alg (WhenExprF [ElseCase a]) = a
   alg a = embed a
+
+-- {<stmt>; /*defer */{<body>}.appRun()} -> {<stmt>; <body>}
+inlineDeferApp :: KtExpr -> KtExpr
+inlineDeferApp = cata alg where
+  alg :: KtExprF KtExpr -> KtExpr
+  alg (StmtF sts) = Stmt $ go <$> sts
+    where
+      go (Run (Defer a)) = a
+      go (Run (Stmt body)) = inlineDeferApp $ Stmt $ mapLast Run body
+      go a = a
+  alg a = embed a
+
+mapLast :: (a -> a) -> [a] -> [a]
+mapLast f ls = reverse $ case reverse ls of
+  [] -> []
+  (end: rest) -> f end : rest
 
 -- If a when case does not cover all cases, an else branch is needed
 -- since Kotlin can sometimes not infer, that all cases are covered, this adds a default case


### PR DESCRIPTION
inline `do` for Effect and ST

[`inlineST`](https://github.com/purescript/purescript/blob/02ecfe6d10fdc02ff4cf599c040707dab1a7281a/src/Language/PureScript/CoreImp/Optimizer/MagicDo.hs#L98) is not yet ported